### PR TITLE
skip disabled DFSR groups

### DIFF
--- a/Custom Sensors/EXEXML/Get-DFSRBacklog.ps1
+++ b/Custom Sensors/EXEXML/Get-DFSRBacklog.ps1
@@ -156,6 +156,10 @@ Function Get-DFSRBacklogInfo ($Computer, $RGroups, $RFolders, $RConnections)
            {
                 $ReplicatedFolderName = $Folder.ReplicatedFolderName
                 $FolderEnabled = $Folder.Enabled
+
+                #skip disabled groups
+                if(!$FolderEnabled) {continue}
+                
                 Foreach ($Connection in $Rconnections)
                 {
                     If ($Connection.ReplicationGroupGUID -eq $ReplicationGroupGUID) 


### PR DESCRIPTION
we noticed errors with null-values, when dfsr-groups were in disabled state