### PR TITLE
Support for more than two replication members

### DIFF
--- a/Custom Sensors/EXEXML/Get-DFSRBacklog.ps1
+++ b/Custom Sensors/EXEXML/Get-DFSRBacklog.ps1
@@ -195,7 +195,7 @@ Function Get-DFSRBacklogInfo ($Computer, $RGroups, $RFolders, $RConnections)
                                         $OutboundPartnerWMI = Get-WmiObject -computername $Smem -Namespace "root\MicrosoftDFS" -Query $WMIQuery
                                         $BacklogCount = $OutboundPartnerWMI.GetOutboundBacklogFileCount($Vv).BacklogFileCount
 					Write-Output "<result>"
-					Write-Output "<channel>${ReplicatedFolderName} In</channel>"
+					Write-Output "<channel>${ReplicatedFolderName} from $Smem</channel>"
 					Write-Output "<value>${BacklogCount}</value>"
 					Write-Output "</result>"  
                                     }
@@ -224,7 +224,7 @@ Function Get-DFSRBacklogInfo ($Computer, $RGroups, $RFolders, $RConnections)
                                         $OutboundPartnerWMI = Get-WmiObject -computername $Smem -Namespace "root\MicrosoftDFS" -Query $WMIQuery
                                         $BacklogCount = $OutboundPartnerWMI.GetOutboundBacklogFileCount($Vv).BacklogFileCount
 					Write-Output "<result>"
-					Write-Output "<channel>${ReplicatedFolderName} Out</channel>"
+					Write-Output "<channel>${ReplicatedFolderName} to $Rmem</channel>"
 					Write-Output "<value>${BacklogCount}</value>"
 					Write-Output "</result>"
                                     }              


### PR DESCRIPTION
Add server name to each channel so you can differentiate the replication link in PRTG when there are more than two replication members for a folder